### PR TITLE
Fix SSL error

### DIFF
--- a/dotemacs.el
+++ b/dotemacs.el
@@ -6,7 +6,6 @@
 (setq
  package-archives '(("gnu" . "http://elpa.gnu.org/packages/")
                     ("org" . "http://orgmode.org/elpa/")
-                    ("marmalade" . "http://marmalade-repo.org/packages/")
                     ("melpa" . "http://melpa.org/packages/")
                     ("melpa-stable" . "http://stable.melpa.org/packages/"))
  package-archive-priorities '(("melpa-stable" . 1)))
@@ -404,11 +403,6 @@
 ;; elixir
 (unless (package-installed-p 'elixir-mode)
   (package-install 'elixir-mode))
-
-;; ensime
-(use-package ensime
-  :ensure t
-  :pin melpa-stable)
 
 (defun eshell-clear-buffer ()
   "Clear eshell"


### PR DESCRIPTION
On setting up a new environment...

First run of Emacs complains that accessing the Marmelade repository results in an SSL error and asks the user if they want to accept an insecure connection always (a) or for the session (s). In the past, we've been accepting "always" and letting it ride.

Research suggests the Marmelade repository is no longer supported. I've removed it from the configuration.

The only package that depended on it was `ensime` for Scala. This issue for another customized setup suggests that ensime is deprecated and should be replaced with "metals".

https://github.com/syl20bnr/spacemacs/issues/12462

Another repo hosting ensime might be installable in a different way:

https://github.com/bbatsov/ensime

Opening this pull request to consider fixing the SSL issue and discuss if anybody uses Scala and it is worth keeping `ensime` around...